### PR TITLE
Update cheap models to latest OpenRouter offerings

### DIFF
--- a/src/qpcommon/completion/availableModels.ts
+++ b/src/qpcommon/completion/availableModels.ts
@@ -1,18 +1,26 @@
 export const AVAILABLE_MODELS = [
   {
-    model: "openai/gpt-4.1-mini",
-    label: "gpt-4.1-mini",
+    model: "openai/gpt-5-nano",
+    label: "gpt-5-nano",
     cost: {
-      prompt: 0.4,
-      completion: 1.6,
+      prompt: 0.05,
+      completion: 0.4,
     },
   },
   {
-    model: "google/gemini-2.0-flash-001",
-    label: "gemini-2.0-flash-001",
+    model: "openai/gpt-5-mini",
+    label: "gpt-5-mini",
     cost: {
-      prompt: 0.1,
-      completion: 0.4,
+      prompt: 0.25,
+      completion: 2,
+    },
+  },
+  {
+    model: "google/gemini-2.5-flash",
+    label: "gemini-2.5-flash",
+    cost: {
+      prompt: 0.3,
+      completion: 2.5,
     },
   },
   {

--- a/src/qpcommon/completion/cheapModels.ts
+++ b/src/qpcommon/completion/cheapModels.ts
@@ -1,5 +1,6 @@
+// Cheap models that can use server API key (updated November 2025)
 export const CHEAP_MODELS = [
-  "openai/gpt-4.1-mini",
-  "google/gemini-2.0-flash-001",
-  "openai/gpt-4o-mini",
+  "openai/gpt-5-nano",
+  "openai/gpt-5-mini",
+  "google/gemini-2.5-flash",
 ];

--- a/src/qpcommon/interface/interface.ts
+++ b/src/qpcommon/interface/interface.ts
@@ -44,7 +44,7 @@ export const emptyChat: Chat = {
     completionTokens: 0,
     estimatedCost: 0,
   },
-  model: "openai/gpt-4.1-mini",
+  model: "openai/gpt-5-nano",
 };
 
 export const chatReducer = (state: Chat, action: ChatAction): Chat => {

--- a/worker/src/routes/completion.ts
+++ b/worker/src/routes/completion.ts
@@ -13,10 +13,12 @@ import {
 
 const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
 
+// Cheap models that can use server API key (updated November 2025)
+// Selected based on low cost and good performance for general tasks
 const CHEAP_MODELS = [
-  'openai/gpt-4.1-mini',
-  'google/gemini-2.0-flash-001',
-  'openai/gpt-4o-mini',
+  'openai/gpt-5-nano',        // $0.05/$0.40 per M tokens - fastest, cheapest
+  'openai/gpt-5-mini',        // $0.25/$2 per M tokens - good balance
+  'google/gemini-2.5-flash',  // $0.30/$2.50 per M tokens - Google option
 ];
 
 const PHRASES_TO_CHECK = [


### PR DESCRIPTION
Updates the cheap models list to use the latest cost-effective models available on OpenRouter (November 2025).

**Changes:**
- Replace openai/gpt-4.1-mini with openai/gpt-5-nano (/bin/zsh.05//bin/zsh.40 per M tokens - cheapest)
- Add openai/gpt-5-mini (/bin/zsh.25/ per M tokens - good balance)
- Update google/gemini-2.0-flash-001 to google/gemini-2.5-flash (/bin/zsh.30/.50 per M tokens)
- Update pricing information and default model selection

**Files Modified:**
- worker/src/routes/completion.ts - Backend cheap models
- src/qpcommon/completion/cheapModels.ts - Frontend cheap models list
- src/qpcommon/completion/availableModels.ts - Model pricing info
- src/qpcommon/interface/interface.ts - Default model selection

**Benefits:**
- Lower costs for server-side API usage
- Access to latest model improvements
- Better performance per dollar