### PR TITLE
Add indexers for common documentation portals

### DIFF
--- a/scripts/DOC_INDEX_README.md
+++ b/scripts/DOC_INDEX_README.md
@@ -49,7 +49,7 @@ MkDocs generates:
 
 ## The Script
 
-**File**: `sphinx_pages_index.py`
+**File**: `doc_pages_index.py`
 
 ### Features
 
@@ -81,30 +81,30 @@ MkDocs generates:
 
 ```bash
 # Simplest usage - auto-detects documentation type
-./sphinx_pages_index.py https://nwb-schema.readthedocs.io/en/latest/  # Sphinx
-./sphinx_pages_index.py https://bids-specification.readthedocs.io/en/stable/  # MkDocs
+./doc_pages_index.py https://nwb-schema.readthedocs.io/en/latest/  # Sphinx
+./doc_pages_index.py https://bids-specification.readthedocs.io/en/stable/  # MkDocs
 
 # Sphinx with _sources/ directory (auto-detected)
-./sphinx_pages_index.py https://nwb-schema.readthedocs.io/en/latest/
+./doc_pages_index.py https://nwb-schema.readthedocs.io/en/latest/
 
 # MkDocs with auto-detected GitHub repository
-./sphinx_pages_index.py https://bids-specification.readthedocs.io/en/stable/
+./doc_pages_index.py https://bids-specification.readthedocs.io/en/stable/
 
 # With explicit repository URL (works for both Sphinx and MkDocs)
-./sphinx_pages_index.py https://docs.datalad.org/en/stable/ \
+./doc_pages_index.py https://docs.datalad.org/en/stable/ \
   --source-repo https://github.com/datalad/datalad/blob/maint/scripts/source
 
 # Validate that URLs are reachable
-./sphinx_pages_index.py https://bids-specification.readthedocs.io/en/stable/ --validate
+./doc_pages_index.py https://bids-specification.readthedocs.io/en/stable/ --validate
 
 # Save to file
-./sphinx_pages_index.py https://nwb-schema.readthedocs.io/en/latest/ -o index.json
+./doc_pages_index.py https://nwb-schema.readthedocs.io/en/latest/ -o index.json
 
 # Text format output
-./sphinx_pages_index.py https://bids-specification.readthedocs.io/en/stable/ --format text
+./doc_pages_index.py https://bids-specification.readthedocs.io/en/stable/ --format text
 
 # Figpack format (compatible with figpack schema)
-./sphinx_pages_index.py https://docs.datalad.org/en/stable/ --format figpack -o doc-pages.json
+./doc_pages_index.py https://docs.datalad.org/en/stable/ --format figpack -o doc-pages.json
 ```
 
 ### Output Format
@@ -225,7 +225,7 @@ The script uses the following priority for source URLs:
 The `--validate` option checks if source URLs are actually reachable:
 
 ```bash
-./sphinx_pages_index.py https://example.com/scripts/ --validate
+./doc_pages_index.py https://example.com/scripts/ --validate
 ```
 
 Features:
@@ -264,7 +264,7 @@ Validating source URLs for 143 pages...
 
 #### NWB Format Documentation (Sphinx with _sources/)
 ```bash
-./sphinx_pages_index.py https://nwb-schema.readthedocs.io/en/latest/ -o nwb.json
+./doc_pages_index.py https://nwb-schema.readthedocs.io/en/latest/ -o nwb.json
 # Auto-detects: Sphinx
 # Uses: _sources/ directory
 # Result: 6 pages with .rst.txt sources
@@ -272,7 +272,7 @@ Validating source URLs for 143 pages...
 
 #### DataLad Documentation (Sphinx with GitHub repo)
 ```bash
-./sphinx_pages_index.py https://docs.datalad.org/en/stable/ \
+./doc_pages_index.py https://docs.datalad.org/en/stable/ \
   --source-repo https://github.com/datalad/datalad/blob/maint/scripts/source \
   -o datalad.json
 # Auto-detects: Sphinx
@@ -282,7 +282,7 @@ Validating source URLs for 143 pages...
 
 #### Sphinx Documentation with Validation
 ```bash
-./sphinx_pages_index.py https://www.sphinx-doc.org/en/master/ --validate
+./doc_pages_index.py https://www.sphinx-doc.org/en/master/ --validate
 # Auto-detects: Sphinx
 # Validates: All source URLs are reachable
 ```
@@ -291,7 +291,7 @@ Validating source URLs for 143 pages...
 
 #### BIDS Specification (MkDocs with auto-detected repo)
 ```bash
-./sphinx_pages_index.py https://bids-specification.readthedocs.io/en/stable/ -o bids.json
+./doc_pages_index.py https://bids-specification.readthedocs.io/en/stable/ -o bids.json
 # Auto-detects: MkDocs
 # Auto-detects repo: https://github.com/bids-standard/bids-specification
 # Filters: 43 unique pages from 1458 search entries (removes anchors)
@@ -300,7 +300,7 @@ Validating source URLs for 143 pages...
 
 #### MkDocs with Manual Repo URL
 ```bash
-./sphinx_pages_index.py https://example-mkdocs.readthedocs.io/en/latest/ \
+./doc_pages_index.py https://example-mkdocs.readthedocs.io/en/latest/ \
   --source-repo https://github.com/org/repo/blob/main/docs \
   --format text
 # Auto-detects: MkDocs
@@ -313,7 +313,7 @@ Validating source URLs for 143 pages...
 #### Figpack Format Output
 ```bash
 # Works with both Sphinx and MkDocs
-./sphinx_pages_index.py https://docs.datalad.org/en/stable/ \
+./doc_pages_index.py https://docs.datalad.org/en/stable/ \
   --format figpack -o doc-pages.json
 
 # Auto-detects documentation type
@@ -322,7 +322,7 @@ Validating source URLs for 143 pages...
 
 #### Python Documentation (Sphinx)
 ```bash
-./sphinx_pages_index.py https://docs.python.org/3/ \
+./doc_pages_index.py https://docs.python.org/3/ \
   --source-repo https://github.com/python/cpython/blob/main/Doc \
   --format text
 ```

--- a/scripts/doc_pages_index.py
+++ b/scripts/doc_pages_index.py
@@ -3,13 +3,13 @@
 Extract all pages from Sphinx or MkDocs documentation and map them to source files.
 
 Usage:
-    sphinx_pages_index.py <docs_url> [options]
+    doc_pages_index.py <docs_url> [options]
 
 Example:
-    sphinx_pages_index.py https://nwb-schema.readthedocs.io/en/latest/
-    sphinx_pages_index.py https://bids-specification.readthedocs.io/en/stable/
-    sphinx_pages_index.py https://docs.datalad.org/en/stable/ --source-repo https://github.com/datalad/datalad/blob/maint/scripts/source
-    sphinx_pages_index.py https://docs.python.org/3/ --validate
+    doc_pages_index.py https://nwb-schema.readthedocs.io/en/latest/
+    doc_pages_index.py https://bids-specification.readthedocs.io/en/stable/
+    doc_pages_index.py https://docs.datalad.org/en/stable/ --source-repo https://github.com/datalad/datalad/blob/maint/scripts/source
+    doc_pages_index.py https://docs.python.org/3/ --validate
 """
 
 import argparse


### PR DESCRIPTION
The overall idea is to get assistant specifications more declarative and just to point to corresponding websites.
Indexers (introduced here) should be able to figure out per URL an index of pages to point to. The inspiration was the https://github.com/yarikoptic/qp/blob/main/src/assistants/figpack-assistant/retrieveFigpackDocs.tsx#L71 and the 

```shell
❯ curl --silent https://flatironinstitute.github.io/figpack/doc-pages.json | head
{
  "docPages": [
    {
      "title": "API Reference",
      "url": "https://flatironinstitute.github.io/figpack/api/index.html",
      "sourceUrl": "https://flatironinstitute.github.io/figpack/_sources/api/index.md.txt",
      "includeFromStart": true
    },
    {
      "title": "Developer Guide",
...
```

so with this script (claude vibe coded) it is already possible to get such listing for various doc engines (with `-o` would be just to file without occluding logging)

- [ ] mkdocs

```shell
❯ ./doc_pages_index.py https://bids-specification.readthedocs.io/en/stable/ --format figpack | head
Detecting documentation type for https://bids-specification.readthedocs.io/en/stable/
✓ Detected: MkDocs documentation
Fetching MkDocs search index from: https://bids-specification.readthedocs.io/en/stable/search/search_index.json
Found 43 unique pages (filtered from 1458 entries)
Attempting to detect source repository from 'Edit this page' links...
✓ Detected source repository: https://github.com/bids-standard/bids-specification/blob/master/src
{
  "docPages": [
    {
      "title": "Changelog",
      "url": "https://bids-specification.readthedocs.io/en/stable/CHANGES.html",
      "sourceUrl": "https://github.com/bids-standard/bids-specification/blob/master/src/CHANGES.md",
      "includeFromStart": true
    },
    {
      "title": "Arterial Spin Labeling",
```

- [x] sphinx

```shell
❯ ./doc_pages_index.py https://docs.datalad.org/en/stable/ --format figpack | head
Detecting documentation type for https://docs.datalad.org/en/stable/
✓ Detected: Sphinx documentation
Fetching Sphinx search index from: https://docs.datalad.org/en/stable/searchindex.js
Found 143 documents
Checking for _sources/ directory...
✓ Found _sources/ directory (will use for source URLs)
{
  "docPages": [
    {
      "title": "Acknowledgments",
      "url": "https://docs.datalad.org/en/stable/acknowledgements.html",
      "sourceUrl": "https://docs.datalad.org/en/stable/_sources/acknowledgements.rst.txt",
      "includeFromStart": true
    },
    {
      "title": "Background and motivation",
```
- [ ] some other sphinx -- fails to determine sources on https://www.hedtags.org/hed-resources/  (see https://github.com/magland/qp/pull/18/files#r2525286258):
```
❯ ./doc_pages_index.py https://www.hedtags.org/hed-resources/ | xclip -i
Detecting documentation type for https://www.hedtags.org/hed-resources/
✓ Detected: Sphinx documentation
Fetching Sphinx search index from: https://www.hedtags.org/hed-resources/searchindex.js
Found 28 documents
Checking for _sources/ directory...
✗ No _sources/ directory found
  Consider providing --source-repo for source file URLs
```
so if not discoverable -- should indeed provide source-repo ... TODO: mention that to copilot if I review that PR it made ;-)
- [ ] hugo ???

So we are just to decide on how we want to wrap it up. Ideally, I would like to see most of the assistants mostly to be a .yaml file definition containing the prompts and documentation sources. But I have not yet reviewed/understood what each one has custom. @magland could you guide me?

establishing then some CI to dump/update them daily should be trivial. We could also add

- not bothering to update if didn't change