### PR TITLE
update default model to gpt-4.1-mini

### DIFF
--- a/src/qpcommon/completion/availableModels.ts
+++ b/src/qpcommon/completion/availableModels.ts
@@ -79,4 +79,12 @@ export const AVAILABLE_MODELS = [
       completion: 0.6,
     },
   },
+  {
+    model: "openai/gpt-4.1-mini",
+    label: "gpt-4.1-mini",
+    cost: {
+      prompt: 0.4,
+      completion: 1.6,
+    },
+  }
 ];

--- a/src/qpcommon/completion/cheapModels.ts
+++ b/src/qpcommon/completion/cheapModels.ts
@@ -3,4 +3,5 @@ export const CHEAP_MODELS = [
   "openai/gpt-5-nano",
   "openai/gpt-5-mini",
   "google/gemini-2.5-flash",
+  "openai/gpt-4.1-mini",
 ];

--- a/src/qpcommon/interface/interface.ts
+++ b/src/qpcommon/interface/interface.ts
@@ -35,6 +35,8 @@ export type ChatAction =
       messageIndex: number;
     };
 
+const defaultModel = "openai/gpt-4.1-mini";
+
 export const emptyChat: Chat = {
   app: getAppName(),
   chatId: "",
@@ -44,7 +46,7 @@ export const emptyChat: Chat = {
     completionTokens: 0,
     estimatedCost: 0,
   },
-  model: "openai/gpt-5-nano",
+  model: defaultModel,
 };
 
 export const chatReducer = (state: Chat, action: ChatAction): Chat => {

--- a/worker/src/routes/completion.ts
+++ b/worker/src/routes/completion.ts
@@ -19,6 +19,7 @@ const CHEAP_MODELS = [
   'openai/gpt-5-nano',        // $0.05/$0.40 per M tokens - fastest, cheapest
   'openai/gpt-5-mini',        // $0.25/$2 per M tokens - good balance
   'google/gemini-2.5-flash',  // $0.30/$2.50 per M tokens - Google option
+  "openai/gpt-4.1-mini",      // $0.40/$1.60 per M tokens
 ];
 
 const PHRASES_TO_CHECK = [


### PR DESCRIPTION
@neuromechanist 

With this PR, I am putting the default back to gpt-4.1-mini for now. Qualitatively gpt-5-nano and gpt-5-mini were slower and made a couple mistakes that I was not finding with gpt-4.1-mini. So let's revert the default since I've been using that for a while and we can switch it once we've done some more testing.