### PR TITLE
Add per-assistant API key support

### DIFF
--- a/src/qpcommon/completion/processCompletion.ts
+++ b/src/qpcommon/completion/processCompletion.ts
@@ -20,6 +20,7 @@ const processCompletion = async (
       type: "function",
       function: tool.toolFunction,
     })),
+    app: chat.app, // Pass assistant name for per-assistant API key routing
   };
 
   // const request: ORRequest = {

--- a/src/qpcommon/types.ts
+++ b/src/qpcommon/types.ts
@@ -82,6 +82,7 @@ export type CompletionRequest = {
   systemMessage: string;
   messages: ChatMessage[];
   tools: ORTool[];
+  app?: string; // Assistant name for per-assistant API key routing
 };
 
 export interface ToolExecutionContext {

--- a/worker/.dev.vars.example
+++ b/worker/.dev.vars.example
@@ -1,0 +1,13 @@
+# Local development environment variables
+# Copy this file to .dev.vars and fill in your actual values
+
+# Global OpenRouter API key (fallback for all assistants)
+OPENROUTER_API_KEY=sk-or-v1-your-global-key-here
+
+# Optional: Per-assistant OpenRouter API keys
+# These override the global key for specific assistants when using cheap models
+# OPENROUTER_API_KEY_HED_ASSISTANT=sk-or-v1-your-hed-specific-key-here
+# OPENROUTER_API_KEY_BIDS_ASSISTANT=sk-or-v1-your-bids-specific-key-here
+
+# Admin key for protected operations
+ADMIN_KEY=your-admin-key-here

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -87,6 +87,7 @@ export type CompletionRequest = {
   systemMessage: string;
   messages: ChatMessage[];
   tools: ORTool[];
+  app?: string; // Assistant name for per-assistant API key routing
 };
 
 export interface ChatRow {

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -3,7 +3,12 @@ main = "src/index.ts"
 compatibility_date = "2024-01-01"
 
 # Environment variables (set these via wrangler secret put or in Cloudflare dashboard)
-# OPENROUTER_API_KEY - for cheap models
+# OPENROUTER_API_KEY - Global fallback key for all assistants (for cheap models)
+# OPENROUTER_API_KEY_<ASSISTANT_NAME> - Optional per-assistant keys (for cheap models)
+#   Examples:
+#   - OPENROUTER_API_KEY_HED_ASSISTANT
+#   - OPENROUTER_API_KEY_BIDS_ASSISTANT
+#   Assistant names are converted from "hed-assistant" to "HED_ASSISTANT" format
 # ADMIN_KEY - for protected operations
 
 # D1 Database binding


### PR DESCRIPTION
## Summary

This PR implements per-assistant API key routing that allows each assistant to have its own OpenRouter API key while maintaining full backward compatibility with the global key.

## Changes

- Added `app` field to `CompletionRequest` type (frontend and worker)
- Updated completion processing to pass assistant name in API requests
- Implemented API key fallback chain in worker:
  1. User-provided key (via `x-openrouter-key` header)
  2. Assistant-specific key (e.g., `OPENROUTER_API_KEY_HED_ASSISTANT`)
  3. Global server key (backward compatibility)
- Updated `wrangler.toml` documentation for environment variable naming
- Added `.dev.vars.example` template for local development

## Environment Variable Naming

Assistant names are converted from kebab-case to SCREAMING_SNAKE_CASE:
- `hed-assistant` → `OPENROUTER_API_KEY_HED_ASSISTANT`
- `bids-assistant` → `OPENROUTER_API_KEY_BIDS_ASSISTANT`

## Testing

Tested locally with two different API keys:
- [x] HED assistant correctly uses assistant-specific key when configured
- [x] Other assistants fall back to global key as expected
- [x] Backward compatibility maintained (global key works for all assistants)

Thanks @magland, for all your help and providing this resource.
Our team can contribute an OpenRouter API key specifically for the HED assistant if that would be helpful. Please let us know if you'd like us to set this up.