### PR TITLE
Add Cerebras models and provider support for fast inference

### DIFF
--- a/worker/src/routes/completion.ts
+++ b/worker/src/routes/completion.ts
@@ -19,7 +19,9 @@ const CHEAP_MODELS = [
   'openai/gpt-5-nano',        // $0.05/$0.40 per M tokens - fastest, cheapest
   'openai/gpt-5-mini',        // $0.25/$2 per M tokens - good balance
   'google/gemini-2.5-flash',  // $0.30/$2.50 per M tokens - Google option
-  "openai/gpt-4.1-mini",      // $0.40/$1.60 per M tokens
+  'openai/gpt-4.1-mini',      // $0.40/$1.60 per M tokens
+  'openai/gpt-oss-120b',      // Cerebras - ultra-fast inference (2700+ tok/s)
+  'qwen/qwen3-235b-a22b-2507', // Cerebras - fast open model
 ];
 
 const PHRASES_TO_CHECK = [
@@ -164,12 +166,17 @@ export async function handleCompletion(
       }
     }
     
-    const requestBody = {
+    const requestBody: Record<string, unknown> = {
       model: body.model,
       messages: [{ role: 'system', content: systemMessage }, ...messages],
       stream: true,
       tools: body.tools,
     };
+
+    // Add provider preference if specified (e.g., "Cerebras" for fast inference)
+    if (body.provider) {
+      requestBody.provider = { only: [body.provider] };
+    }
     
     const response = await fetch(OPENROUTER_API_URL, {
       method: 'POST',

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -87,7 +87,8 @@ export type CompletionRequest = {
   systemMessage: string;
   messages: ChatMessage[];
   tools: ORTool[];
-  app?: string; // Assistant name for per-assistant API key routing
+  app?: string;       // Assistant name for per-assistant API key routing
+  provider?: string;  // Optional provider preference (e.g., "Cerebras", "SambaNova")
 };
 
 export interface ChatRow {


### PR DESCRIPTION
## Summary
- Add `openai/gpt-oss-120b` and `qwen/qwen3-235b-a22b-2507` to CHEAP_MODELS
- Add optional `provider` field to CompletionRequest for routing to specific inference providers

## Rationale
These Cerebras-hosted models offer:
- Very fast throughput (2000+ tokens/s)
- Low cost
- Open model weights

The provider field allows clients to specify inference provider preference (e.g., "Cerebras", "SambaNova") when needed.

## Question
Should we also add the `provider` field to the frontend `CompletionRequest` type in `src/qpcommon/types.ts`? Currently this PR only adds it to the worker types.