### PR TITLE
Add hedtags.org to CORS allowed origins

### DIFF
--- a/worker/src/utils/cors.ts
+++ b/worker/src/utils/cors.ts
@@ -2,7 +2,8 @@
 
 const ALLOWED_ORIGINS = [
   'http://localhost:5173',
-  /^https:\/\/.*\.neurosift\.app$/
+  /^https:\/\/.*\.neurosift\.app$/,
+  /^https:\/\/(www\.)?hedtags\.org$/
 ];
 
 export function isOriginAllowed(origin: string | null): boolean {


### PR DESCRIPTION
## Summary
- Add `hedtags.org` and `www.hedtags.org` to CORS allowed origins
- Required for the HED chat widget on hedtags.org to access the QP completion API

## Test plan
- [ ] Verify CORS preflight requests from hedtags.org return proper Access-Control-Allow-Origin header
- [ ] Test chat widget on hedtags.org after deployment