### PR TITLE
Add embeddable chat widget for QP assistants

### DIFF
--- a/embed/README.md
+++ b/embed/README.md
@@ -10,9 +10,10 @@ A portable, embeddable chat widget for QP assistants. Drop it into any website t
 - Streaming responses
 - Suggested questions
 - Resizable chat window
+- **Pop-out to new window** for side-by-side viewing with documentation
 - Mobile responsive
 - Dark mode support (auto-detects `data-bs-theme`, `data-theme`, or `.dark` class)
-- Persistent chat history via localStorage
+- Persistent chat history via localStorage (shared across pages and pop-out windows)
 
 ## Quick Start
 
@@ -69,7 +70,9 @@ QPChat.init({
   },
 
   // Advanced
-  cssUrl: 'qp-chat-widget.css'       // Custom CSS file URL
+  cssUrl: 'qp-chat-widget.css',      // Custom CSS file URL
+  jsUrl: 'qp-chat-widget.js',        // Custom JS file URL (used for pop-out)
+  fullscreen: false                  // When true, renders as full-page chat (for pop-out windows)
 });
 ```
 
@@ -148,6 +151,26 @@ Override CSS variables for custom theming:
   --qp-text-muted: #6b7280;
   --qp-text-light: #9ca3af;
 }
+```
+
+## Pop-out Window
+
+Click the pop-out button (arrow icon) in the chat header to open the chat in a new window. This allows you to:
+
+- View documentation and chat side-by-side
+- Continue the same conversation in the pop-out window
+- Resize the pop-out window independently
+
+The chat history is shared via localStorage, so the conversation persists between the embedded widget and the pop-out window (as long as they're on the same domain).
+
+**Note:** For the pop-out feature to work correctly, you should configure `jsUrl` and `cssUrl` with absolute URLs pointing to where your widget files are hosted:
+
+```javascript
+QPChat.init({
+  // ... other options
+  cssUrl: 'https://your-cdn.com/qp-chat-widget.css',
+  jsUrl: 'https://your-cdn.com/qp-chat-widget.js'
+});
 ```
 
 ## Dark Mode

--- a/embed/examples/basic.html
+++ b/embed/examples/basic.html
@@ -26,6 +26,7 @@
     <li>Streaming responses</li>
     <li>Suggested questions</li>
     <li>Resizable window</li>
+    <li><strong>Pop-out to new window</strong> (click the arrow icon in the header)</li>
     <li>Mobile responsive</li>
     <li>Dark mode support</li>
   </ul>

--- a/embed/qp-chat-widget.css
+++ b/embed/qp-chat-widget.css
@@ -139,6 +139,37 @@
 .qp-chat-status-dot.offline { background: #ef4444; }
 .qp-chat-status-dot.checking { background: #f59e0b; }
 
+/* Header actions container */
+.qp-chat-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+/* Pop-out button */
+.qp-chat-popout {
+  background: transparent;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.7);
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.qp-chat-popout:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+}
+
+.qp-chat-popout svg {
+  width: 16px;
+  height: 16px;
+}
+
 /* Reset button */
 .qp-chat-reset {
   background: transparent;
@@ -704,4 +735,37 @@
 [data-theme="dark"] .qp-chat-resize-handle:hover::before,
 .dark .qp-chat-resize-handle:hover::before {
   border-color: #3b82f6;
+}
+
+/* Fullscreen mode (for popup windows) */
+.qp-chat-window.fullscreen {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+  max-width: none !important;
+  max-height: none !important;
+  border-radius: 0 !important;
+  border: none !important;
+  z-index: 1 !important;
+  animation: none !important;
+}
+
+.qp-chat-window.fullscreen .qp-chat-resize-handle {
+  display: none !important;
+}
+
+.qp-chat-window.fullscreen .qp-chat-popout {
+  display: none !important;
+}
+
+.qp-chat-window.fullscreen .qp-chat-header {
+  border-radius: 0;
+}
+
+.qp-chat-window.fullscreen .qp-chat-messages {
+  max-height: none;
 }


### PR DESCRIPTION
## Summary
Adds a standalone, embeddable chat widget that can be dropped into any website to provide AI chat functionality using QP backend.

## Features
- Standalone vanilla JavaScript and CSS (no frameworks required)
- Configurable for any QP assistant
- Markdown rendering (headers, lists, tables, code blocks)
- Streaming responses
- Suggested questions
- Resizable chat window
- Mobile responsive
- Dark mode support (auto-detects `data-bs-theme`, `data-theme`, or `.dark` class)
- Persistent chat history via localStorage

## Files Added
- `embed/qp-chat-widget.js` - Main widget code
- `embed/qp-chat-widget.css` - Widget styles
- `embed/README.md` - Usage documentation
- `embed/examples/basic.html` - Basic usage example:
<img width="534" height="472" alt="image" src="https://github.com/user-attachments/assets/39025a91-8085-4c39-a94a-d70bf14e1d81" />


## Usage Example
```html
<link rel="stylesheet" href="qp-chat-widget.css">
<script src="qp-chat-widget.js"></script>
<script>
  QPChat.init({
    title: 'My Assistant',
    app: 'my-assistant',
    systemPrompt: 'You are a helpful assistant.',
    suggestedQuestions: ['What can you help with?']
  });
</script>
```

## Real-World Usage
This widget is already deployed on https://www.hedtags.org/ as the HED Assistant chat widget.

## Test Plan
- [x] Test basic chat functionality
- [x] Test markdown rendering (headers, code blocks, tables)
- [x] Test dark mode switching
- [x] Test mobile responsiveness
- [x] Test resize functionality