### PR TITLE
Add repronim-assistant for ReproNim reproducible neuroimaging tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.npm
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A multi-tenant AI chat platform that hosts specialized AI assistants, each acces
 
 ## Chat Assistants
 
-This repository supports eight specialized chat applications:
+This repository supports nine specialized chat applications:
 
 ### 1. **stan-assistant**
 
@@ -37,6 +37,10 @@ Assistant for the [Brain Imaging Data Structure (BIDS)](https://bids.neuroimagin
 ### 8. **hed-assistant**
 
 Assistant for [Hierarchical Event Descriptors (HED)](https://www.hedtags.org/). Provides guidance on annotating events and data using HED tags, based on the HED specification and resources documentation.
+
+### 9. **repronim-assistant**
+
+Assistant for [ReproNim](https://repronim.org/) (Reproducible Neuroimaging). Helps with reproducibility tools and best practices including HeuDiConv, DataLad, Neurodocker, and related projects for data conversion, version control, and containerization.
 
 ## Architecture
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import dandisetExplorerPreferences from "./assistants/dandiset-explorer/preferen
 import figpackAssistantPreferences from "./assistants/figpack-assistant/preferences";
 import bidsAssistantPreferences from "./assistants/bids-assistant/preferences";
 import hedAssistantPreferences from "./assistants/hed-assistant/preferences";
+import repronimAssistantPreferences from "./assistants/repronim-assistant/preferences";
 
 function App() {
   const preferences = useMemo(() => {
@@ -31,6 +32,8 @@ function App() {
       return bidsAssistantPreferences;
     } else if (appName === "hed-assistant") {
       return hedAssistantPreferences;
+    } else if (appName === "repronim-assistant") {
+      return repronimAssistantPreferences;
     } else {
       return {
         getAssistantSystemPrompt: async () => "Unknown assistant",

--- a/src/assistants/repronim-assistant/getTools.ts
+++ b/src/assistants/repronim-assistant/getTools.ts
@@ -1,0 +1,8 @@
+import * as retrieveRepronimDocs from "./retrieveRepronimDocs";
+import { QPTool } from "../../qpcommon/types";
+
+const getTools = async (): Promise<QPTool[]> => {
+  return [retrieveRepronimDocs];
+};
+
+export default getTools;

--- a/src/assistants/repronim-assistant/integration.test.ts
+++ b/src/assistants/repronim-assistant/integration.test.ts
@@ -1,0 +1,181 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+describe('ReproNim Assistant - Integration', () => {
+  describe('File Structure', () => {
+    const assistantPath = 'src/assistants/repronim-assistant';
+
+    it('should have all required assistant files', () => {
+      const requiredFiles = [
+        'repronimAssistantSystemPrompt.ts',
+        'getTools.ts',
+        'preferences.tsx',
+        'retrieveRepronimDocs.tsx',
+      ];
+
+      requiredFiles.forEach(file => {
+        const filePath = join(process.cwd(), assistantPath, file);
+        expect(() => readFileSync(filePath, 'utf8')).not.toThrow();
+      });
+    });
+
+    it('should have system prompt exported', () => {
+      const filePath = join(process.cwd(), assistantPath, 'repronimAssistantSystemPrompt.ts');
+      const content = readFileSync(filePath, 'utf8');
+
+      expect(content).toContain('export default');
+      expect(content).toContain('ReproNim');
+      expect(content.length).toBeGreaterThan(1000); // Ensure it's substantial
+    });
+
+    it('should export getTools function', () => {
+      const filePath = join(process.cwd(), assistantPath, 'getTools.ts');
+      const content = readFileSync(filePath, 'utf8');
+
+      expect(content).toContain('export default');
+      expect(content).toContain('retrieveRepronimDocs');
+    });
+
+    it('should export preferences object', () => {
+      const filePath = join(process.cwd(), assistantPath, 'preferences.tsx');
+      const content = readFileSync(filePath, 'utf8');
+
+      expect(content).toContain('export default');
+      expect(content).toContain('Preferences');
+      expect(content).toContain('repronimAssistantSystemPrompt');
+    });
+  });
+
+  describe('App Integration', () => {
+    it('should be registered in App.tsx', () => {
+      const appPath = join(process.cwd(), 'src/App.tsx');
+      const content = readFileSync(appPath, 'utf8');
+
+      expect(content).toContain('repronim-assistant');
+      expect(content).toContain('repronimAssistantPreferences');
+      expect(content).toContain('from "./assistants/repronim-assistant/preferences"');
+    });
+
+    it('should be registered in tools/getTools.ts', () => {
+      const toolsPath = join(process.cwd(), 'src/tools/getTools.ts');
+      const content = readFileSync(toolsPath, 'utf8');
+
+      expect(content).toContain('repronim-assistant');
+      expect(content).toContain('getRepronimAssistantTools');
+      expect(content).toContain('from "../assistants/repronim-assistant/getTools"');
+    });
+  });
+
+  describe('Documentation Tool', () => {
+    it('should have retrieveRepronimDocs tool with proper structure', () => {
+      const toolPath = join(process.cwd(), 'src/assistants/repronim-assistant/retrieveRepronimDocs.tsx');
+      const content = readFileSync(toolPath, 'utf8');
+
+      expect(content).toContain('export const toolFunction');
+      expect(content).toContain('retrieve_repronim_docs');
+      expect(content).toContain('export const execute');
+      expect(content).toContain('export const getDocPages');
+      expect(content).toContain('export const getDetailedDescription');
+    });
+
+    it('should have comprehensive documentation pages defined', () => {
+      const toolPath = join(process.cwd(), 'src/assistants/repronim-assistant/retrieveRepronimDocs.tsx');
+      const content = readFileSync(toolPath, 'utf8');
+
+      // Check for key ReproNim tools/resources
+      expect(content).toContain('HeuDiConv');
+      expect(content).toContain('DataLad');
+      expect(content).toContain('Neurodocker');
+      expect(content).toContain('ReproIn');
+
+      // Check for ReproStim documentation
+      expect(content).toContain('ReproStim Introduction');
+      expect(content).toContain('ReproStim CLI');
+      expect(content).toContain('reprostim.readthedocs.io');
+
+      // Check for training modules
+      expect(content).toContain('module-intro');
+      expect(content).toContain('module-reproducible-basics');
+      expect(content).toContain('module-FAIR-data');
+
+      // Verify we have a reasonable number of docs (now including ReproStim docs)
+      const docMatches = content.match(/title:/g);
+      expect(docMatches).toBeDefined();
+      expect(docMatches!.length).toBeGreaterThan(25); // At least 25 docs with ReproStim
+    });
+
+    it('should have preloaded documents configured', () => {
+      const toolPath = join(process.cwd(), 'src/assistants/repronim-assistant/retrieveRepronimDocs.tsx');
+      const content = readFileSync(toolPath, 'utf8');
+
+      expect(content).toContain('includeFromStart: true');
+
+      // Should have at least 3 preloaded docs
+      const preloadMatches = content.match(/includeFromStart: true/g);
+      expect(preloadMatches).toBeDefined();
+      expect(preloadMatches!.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('Assistant Content', () => {
+    it('should have ReproNim-specific content in system prompt', () => {
+      const promptPath = join(process.cwd(), 'src/assistants/repronim-assistant/repronimAssistantSystemPrompt.ts');
+      const content = readFileSync(promptPath, 'utf8');
+
+      // ReproNim-specific terms
+      expect(content).toContain('ReproNim');
+      expect(content).toContain('reproducible');
+      expect(content).toContain('neuroimaging');
+      expect(content).toContain('repronim.org');
+
+      // Key tools should be mentioned
+      expect(content).toContain('HeuDiConv');
+      expect(content).toContain('DataLad');
+      expect(content).toContain('Neurodocker');
+      expect(content).toContain('containers');
+
+      // Documentation requirements
+      expect(content).toContain('retrieve_repronim_docs');
+    });
+
+    it('should reference related assistants', () => {
+      const promptPath = join(process.cwd(), 'src/assistants/repronim-assistant/repronimAssistantSystemPrompt.ts');
+      const content = readFileSync(promptPath, 'utf8');
+
+      // Should reference other specialized assistants
+      expect(content).toContain('bids-assistant.neurosift.app');
+      expect(content).toContain('hed-assistant.neurosift.app');
+      expect(content).toContain('nwb-assistant.neurosift.app');
+    });
+
+    it('should have suggested prompts in preferences', () => {
+      const prefsPath = join(process.cwd(), 'src/assistants/repronim-assistant/preferences.tsx');
+      const content = readFileSync(prefsPath, 'utf8');
+
+      expect(content).toContain('suggestedPrompts');
+      expect(content).toContain('HeuDiConv');
+      expect(content).toContain('DataLad');
+      expect(content).toContain('Neurodocker');
+    });
+  });
+
+  describe('Documentation', () => {
+    it('should be documented in README', () => {
+      const readmePath = join(process.cwd(), 'README.md');
+      const content = readFileSync(readmePath, 'utf8');
+
+      expect(content).toContain('repronim-assistant');
+      expect(content).toContain('ReproNim');
+      expect(content).toContain('nine'); // nine assistants
+    });
+
+    it('should be documented in CLAUDE.md', () => {
+      const claudePath = join(process.cwd(), 'CLAUDE.md');
+      const content = readFileSync(claudePath, 'utf8');
+
+      expect(content).toContain('repronim-assistant');
+      expect(content).toContain('ReproNim');
+    });
+  });
+});

--- a/src/assistants/repronim-assistant/preferences.tsx
+++ b/src/assistants/repronim-assistant/preferences.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from "react";
+import { Preferences } from "../../qpcommon/MainWindow";
+import repronimAssistantSystemPrompt from "./repronimAssistantSystemPrompt";
+import { getDocPages } from "./retrieveRepronimDocs";
+
+// eslint-disable-next-line react-refresh/only-export-components
+const AssistantDisplayInfo = () => {
+  const repronimUrl = "https://repronim.org/";
+  const repronimGithubUrl = "https://github.com/ReproNim";
+  const heudiconvUrl = "https://heudiconv.readthedocs.io/";
+  const dataladUrl = "https://www.datalad.org/";
+  const neurodockerUrl = "https://github.com/ReproNim/neurodocker";
+  const docPages = useMemo(() => getDocPages(), []);
+  return (
+    <div style={{ maxWidth: "600px", margin: "0 auto" }}>
+      <p>
+        This is a technical assistant for{" "}
+        <a href={repronimUrl} target="_blank" rel="noopener noreferrer">
+          ReproNim
+        </a>{" "}
+        (Reproducible Neuroimaging) that provides guidance, troubleshooting, and
+        explanations for reproducible neuroimaging workflows and tools.
+      </p>
+      <p>
+        Key tools:{" "}
+        <a href={heudiconvUrl} target="_blank" rel="noopener noreferrer">
+          HeuDiConv
+        </a>{" "}
+        |{" "}
+        <a href={dataladUrl} target="_blank" rel="noopener noreferrer">
+          DataLad
+        </a>{" "}
+        |{" "}
+        <a href={neurodockerUrl} target="_blank" rel="noopener noreferrer">
+          Neurodocker
+        </a>{" "}
+        |{" "}
+        <a href={repronimGithubUrl} target="_blank" rel="noopener noreferrer">
+          GitHub
+        </a>
+      </p>
+      <p>
+        {docPages.map((doc, index) => (
+          <span key={doc.url}>
+            <a href={doc.url} target="_blank" rel="noopener noreferrer">
+              {doc.title}
+            </a>
+            {index < docPages.length - 1 ? " | " : ""}
+          </span>
+        ))}
+      </p>
+    </div>
+  );
+};
+
+const preferences: Preferences = {
+  getAssistantSystemPrompt: async () => repronimAssistantSystemPrompt,
+  assistantDisplayInfo: <AssistantDisplayInfo />,
+  suggestedPrompts: [
+    "How do I convert DICOM files to BIDS using HeuDiConv?",
+    "What is DataLad and how can it help with data management?",
+    "How do I create a reproducible neuroimaging container with Neurodocker?",
+    "What is the ReproIn convention for scanner setup?",
+  ],
+  requiresJupyter: false,
+};
+
+export default preferences;

--- a/src/assistants/repronim-assistant/repronimAssistantSystemPrompt.ts
+++ b/src/assistants/repronim-assistant/repronimAssistantSystemPrompt.ts
@@ -1,0 +1,134 @@
+const repronimAssistantSystemPrompt = `
+You are a technical assistant specialized in helping users with ReproNim (Reproducible Neuroimaging) and its ecosystem of tools for improving reproducibility in neuroimaging research.
+
+ReproNim is an NIH-funded center dedicated to developing tools and training to increase efficiency, rigor, reproducibility, transparency, and FAIRness in neuroimaging.
+
+You provide explanations, guidance, troubleshooting, and best practices for reproducible neuroimaging workflows, covering both ReproNim-developed projects and closely related community tools.
+
+## Core ReproNim Projects
+
+### Data Acquisition, Conversion & Organization
+- **HeuDiConv** (https://github.com/nipy/heudiconv) - Flexible DICOM converter for organizing brain imaging data into structured directory layouts, particularly BIDS
+- **ReproIn** (https://github.com/ReproNim/reproin) - Convention and setup for automatic generation of shareable, version-controlled BIDS datasets directly from MR scanners
+
+### Containerization & Software Management
+- **Neurodocker** (https://github.com/ReproNim/neurodocker) - Generate custom Docker and Singularity/Apptainer containers for neuroimaging, and minimize existing containers
+- **ReproNim/containers** (https://github.com/ReproNim/containers) - DataLad dataset with Singularity container images for neuroimaging analysis pipelines
+
+### Data Management & Version Control
+- **DataLad** (https://www.datalad.org/, https://github.com/datalad/datalad) - Distributed data management system built on git and git-annex for version control of data and code
+- **datalad-container** (https://github.com/datalad/datalad-container) - DataLad extension for working with containerized computational environments
+
+### Research Data Standards
+- **ReproSchema** (https://github.com/ReproNim/reproschema) - Standardized form generation and data collection schema to harmonize results across projects
+- **reproschema-py** (https://github.com/ReproNim/reproschema-py) - Python library for working with ReproSchema
+
+### Stimulus Capture & Time Synchronization
+- **ReproStim** (https://github.com/ReproNim/reprostim, docs: https://reprostim.readthedocs.io/) - Tools for automated capture and time synchronization of audio-visual stimuli presented during neuroimaging sessions. Features include screen/video capture, QR code-based time synchronization (ReproFlow), PsychoPy integration, and BIDS-compatible output
+
+### Workflow & Execution Management
+- **ReproMan** (https://github.com/ReproNim/reproman) - Command line tool and Python library for managing computational environments and running analyses reproducibly
+
+## Related Community Projects
+
+ReproNim embraces and promotes these important standards and tools:
+
+### Data Standards
+- **BIDS** (Brain Imaging Data Structure, https://bids.neuroimaging.io/) - Community standard for organizing neuroimaging and behavioral data
+- **NIDM** (Neuroimaging Data Model) - Standard for describing neuroimaging experiments and results
+- **HED** (Hierarchical Events Descriptor) - Standard for describing events in any experiments
+- **NWB** (Neurodata Without Borders) - Data standard for neurophysiology
+
+### Neuroimaging Tools
+- **Nipype** (https://nipype.readthedocs.io/) - Workflow engine for neuroimaging
+- **fMRIPrep** (https://fmriprep.org/) - Robust fMRI preprocessing pipeline
+
+### Data Discovery
+- **Neurobagel** (https://neurobagel.org/) - Federated search across neuroimaging datasets
+
+### Data Archives of relevance
+
+- **OpenNeuro** (https://openneuro.org/) - Free platform for sharing BIDS datasets
+- **DANDI** (https://dandiarchive.org/) - Archive for neurophysiology data
+
+Note that both provide DataLad (git/git-annex) support to access their data.
+
+## ReproNim Training Resources
+
+ReproNim provides extensive training materials:
+- **Module Introduction**: http://www.repronim.org/module-intro/
+- **Reproducibility Basics** (shell, git, package managers): http://www.repronim.org/module-reproducible-basics/
+- **FAIR Data**: http://www.repronim.org/module-FAIR-data/
+- **Data Processing**: http://www.repronim.org/module-dataprocessing/
+- **Statistics**: http://www.repronim.org/module-stats/
+- **First Fridays Webinars**: Monthly webinar series on reproducibility
+- **ABCD-ReproNim Course**: 12-week course on reproducible analysis of large datasets
+- **Fellowship Program**: Train-the-trainer program for reproducibility education
+
+## Related Specialized Assistants
+
+When a user's question would benefit from deeper expertise in a specific area, recommend these specialized assistants available at neurosift.app:
+
+- **BIDS Assistant** (https://bids-assistant.neurosift.app/chat) - For detailed questions about the Brain Imaging Data Structure specification, file naming conventions, and BIDS validation
+- **HED Assistant** (https://hed-assistant.neurosift.app/chat) - For Hierarchical Event Descriptors (HED) annotation questions and BIDS event annotation
+- **NWB Assistant** (https://nwb-assistant.neurosift.app/chat) - For Neurodata Without Borders format questions and PyNWB usage
+- **Dandiset Explorer** (https://dandiset-explorer.neurosift.app/chat) - For exploring and working with datasets on the DANDI archive
+
+You can answer general questions about these standards and their relationship to reproducible neuroimaging, but for detailed specification questions, recommend the specialized assistant.
+
+## Communication Guidelines
+
+You must concentrate on the topics of reproducible neuroimaging and ReproNim's ecosystem of tools.
+All responses should be accurate and based on official documentation and best practices.
+When a user's question is ambiguous, assume the most likely meaning and provide a useful starting point, but ask clarifying questions when necessary.
+Communicate in a formal and technical style, prioritizing precision and accuracy while remaining clear.
+Balance clarity and technical accuracy, starting with accessible explanations and then expanding into more detail when needed.
+Answers should be structured and easy to follow, with examples where appropriate.
+Proactively suggest related tools, workflows, or best practices when relevant to the user's query, while remaining concise and focused.
+
+The main ReproNim website is https://repronim.org/
+The GitHub organization is https://github.com/ReproNim
+
+Do not suggest further exploration unless it is for something where you explicitly know how to help.
+
+You will respond with markdown formatted text.
+
+Be concise in your answers, including only the most relevant information unless told otherwise.
+
+Before responding, use the retrieve_repronim_docs tool to get any documentation you need.
+Include links to relevant documents in your response.
+
+Do not retrieve docs that have already been loaded or preloaded.
+Retrieve multiple relevant documents at once so you have all the information needed.
+Get background information documents in addition to specific documents for answering questions.
+If you have already loaded a document, you don't need to load it again.
+
+If you are unsure, do not guess about functionality or hallucinate information.
+Stick to what you can learn from the documents.
+Feel free to read as many documents as you need.
+
+You should only answer questions related to reproducible neuroimaging, ReproNim tools, and closely related community projects. Use the retrieve_repronim_docs tool to get relevant information before answering.
+
+Common topics include:
+
+- Converting DICOM data to BIDS using HeuDiConv
+- Setting up ReproIn conventions at scanner facilities
+- Creating reproducible containers with Neurodocker
+- Version controlling datasets with DataLad
+- Managing computational environments with DataLad and containers
+- Understanding FAIR data principles
+- Designing reproducible analysis workflows
+- Training resources for reproducibility skills
+- Best practices for sharing neuroimaging data
+- Capturing and synchronizing stimuli with ReproStim
+- Time synchronization using QR codes and ReproFlow
+
+The markdown renderer supports LaTeX math enclosed in dollar signs, e.g. $\\alpha + \\beta = 1$.
+Use LaTeX math when appropriate.
+For separate line math, use double dollar signs. Never use \\begin{eqnarray*} or any other LaTeX environment.
+Just use dollar signs.
+
+When providing examples of commands, file structures, or code, use code blocks for clarity.
+`;
+
+export default repronimAssistantSystemPrompt;

--- a/src/assistants/repronim-assistant/retrieveRepronimDocs.test.ts
+++ b/src/assistants/repronim-assistant/retrieveRepronimDocs.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import { execute, getDetailedDescription, getDocPages } from './retrieveRepronimDocs';
+
+describe('ReproNim Assistant - retrieveRepronimDocs', () => {
+  describe('getDocPages', () => {
+    it('should return an array of ReproNim document pages', () => {
+      const docPages = getDocPages();
+
+      expect(docPages).toBeInstanceOf(Array);
+      expect(docPages.length).toBeGreaterThan(0);
+    });
+
+    it('should have a reasonable number of documents', () => {
+      const docPages = getDocPages();
+
+      // Should have at least 15 documentation pages
+      expect(docPages.length).toBeGreaterThanOrEqual(15);
+    });
+
+    it('should have core documents marked for preloading', () => {
+      const docPages = getDocPages();
+      const preloadedDocs = docPages.filter(doc => doc.includeFromStart);
+
+      expect(preloadedDocs.length).toBeGreaterThan(0);
+
+      // Verify key documents are preloaded
+      const titles = preloadedDocs.map(doc => doc.title);
+      expect(titles.some(t => t.includes('HeuDiConv'))).toBe(true);
+      expect(titles.some(t => t.includes('DataLad'))).toBe(true);
+      expect(titles.some(t => t.includes('Neurodocker'))).toBe(true);
+      expect(titles.some(t => t.includes('ReproStim'))).toBe(true);
+    });
+
+    it('should have valid URLs for all documents', () => {
+      const docPages = getDocPages();
+
+      docPages.forEach(doc => {
+        expect(doc.url).toMatch(/^https?:\/\//);
+        expect(doc.sourceUrl).toMatch(/^https?:\/\//);
+        // Source URLs should be raw content URLs
+        expect(doc.sourceUrl).toMatch(/raw\.githubusercontent\.com|readthedocs/);
+      });
+    });
+
+    it('should include key ReproNim tools documentation', () => {
+      const docPages = getDocPages();
+      const titles = docPages.map(doc => doc.title).join(' ');
+
+      // Check for major ReproNim tools
+      expect(titles).toContain('HeuDiConv');
+      expect(titles).toContain('DataLad');
+      expect(titles).toContain('Neurodocker');
+      expect(titles).toContain('ReproIn');
+      expect(titles).toContain('ReproStim');
+    });
+
+    it('should include comprehensive ReproStim documentation', () => {
+      const docPages = getDocPages();
+      const reprostimDocs = docPages.filter(doc => doc.title.includes('ReproStim'));
+
+      // Should have multiple ReproStim docs
+      expect(reprostimDocs.length).toBeGreaterThan(5);
+
+      // Check for specific ReproStim documentation
+      const titles = reprostimDocs.map(doc => doc.title).join(' ');
+      expect(titles).toContain('Introduction');
+      expect(titles).toContain('CLI');
+      expect(titles).toContain('Installation');
+    });
+
+    it('should include training modules', () => {
+      const docPages = getDocPages();
+      const urls = docPages.map(doc => doc.url).join(' ');
+
+      expect(urls).toContain('module-intro');
+      expect(urls).toContain('module-reproducible-basics');
+      expect(urls).toContain('module-FAIR-data');
+    });
+
+    it('should have required properties for each document', () => {
+      const docPages = getDocPages();
+
+      docPages.forEach(doc => {
+        expect(doc).toHaveProperty('title');
+        expect(doc).toHaveProperty('url');
+        expect(doc).toHaveProperty('sourceUrl');
+        expect(doc).toHaveProperty('includeFromStart');
+        expect(typeof doc.title).toBe('string');
+        expect(typeof doc.url).toBe('string');
+        expect(typeof doc.sourceUrl).toBe('string');
+        expect(typeof doc.includeFromStart).toBe('boolean');
+      });
+    });
+  });
+
+  describe('execute', () => {
+    // Note: Network tests are skipped in test environment due to CORS restrictions
+    // These would work in a real browser environment
+    it.skip('should fetch ReproNim documents successfully', async () => {
+      const docPages = getDocPages();
+      const testUrls = [docPages[0].url];
+
+      const result = await execute({ urls: testUrls }, {});
+
+      expect(result).toHaveProperty('result');
+      expect(typeof result.result).toBe('string');
+
+      const parsed = JSON.parse(result.result);
+      expect(parsed).toBeInstanceOf(Array);
+      expect(parsed[0]).toHaveProperty('url');
+      expect(parsed[0]).toHaveProperty('content');
+      expect(parsed[0].content.length).toBeGreaterThan(0);
+    });
+
+    it.skip('should handle multiple document requests', async () => {
+      const docPages = getDocPages();
+      const testUrls = [docPages[0].url, docPages[1].url];
+
+      const result = await execute({ urls: testUrls }, {});
+      const parsed = JSON.parse(result.result);
+
+      expect(parsed.length).toBe(2);
+      expect(parsed[0].url).toBe(testUrls[0]);
+      expect(parsed[1].url).toBe(testUrls[1]);
+    });
+
+    it('should handle invalid URLs gracefully', async () => {
+      const testUrls = [
+        'https://example.com/nonexistent-repronim-doc.html',
+      ];
+
+      const result = await execute({ urls: testUrls }, {});
+
+      // Should still return a result, even if it's an error
+      expect(result).toHaveProperty('result');
+      expect(typeof result.result).toBe('string');
+    });
+  });
+
+  describe('getDetailedDescription', () => {
+    it('should return a detailed description string', async () => {
+      const description = await getDetailedDescription();
+
+      expect(typeof description).toBe('string');
+      expect(description.length).toBeGreaterThan(0);
+    });
+
+    it('should list all available documents', async () => {
+      const description = await getDetailedDescription();
+
+      expect(description).toContain('HeuDiConv');
+      expect(description).toContain('DataLad');
+      expect(description).toContain('Neurodocker');
+    });
+
+    it('should include preloaded content indicator', async () => {
+      const description = await getDetailedDescription();
+
+      expect(description).toContain('preloaded');
+    });
+
+    it('should provide valid JSON schema information', async () => {
+      const description = await getDetailedDescription();
+
+      expect(description).toContain('document URL');
+      expect(description).toContain('document content');
+    });
+
+    it('should mention ReproNim in the description', async () => {
+      const description = await getDetailedDescription();
+
+      expect(description).toContain('ReproNim');
+    });
+  });
+});

--- a/src/assistants/repronim-assistant/retrieveRepronimDocs.tsx
+++ b/src/assistants/repronim-assistant/retrieveRepronimDocs.tsx
@@ -1,0 +1,424 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ORToolCall } from "../../qpcommon/completion/openRouterTypes";
+import { ChatMessage, QPFunctionDescription } from "../../qpcommon/types";
+
+export const toolFunction: QPFunctionDescription = {
+  name: "retrieve_repronim_docs",
+  description:
+    "Retrieve content from a list of ReproNim and related tool documentation URLs.",
+  parameters: {
+    type: "object",
+    properties: {
+      urls: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+        description: "List of document URLs to retrieve",
+      },
+    },
+    required: ["urls"],
+  },
+};
+
+type RetrieveRepronimDocsParams = {
+  urls: string[];
+};
+
+export type DocPage = {
+  title: string;
+  url: string;
+  sourceUrl: string;
+  includeFromStart: boolean;
+};
+
+export const getDocPages = (): DocPage[] => {
+  return [
+    // HeuDiConv documentation
+    {
+      title: "HeuDiConv Quickstart",
+      url: "https://heudiconv.readthedocs.io/en/latest/quickstart.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/nipy/heudiconv/master/docs/quickstart.rst",
+      includeFromStart: true,
+    },
+    {
+      title: "HeuDiConv Installation",
+      url: "https://heudiconv.readthedocs.io/en/latest/installation.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/nipy/heudiconv/master/docs/installation.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "HeuDiConv Heuristics",
+      url: "https://heudiconv.readthedocs.io/en/latest/heuristics.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/nipy/heudiconv/master/docs/heuristics.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "HeuDiConv Tutorials",
+      url: "https://heudiconv.readthedocs.io/en/latest/tutorials.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/nipy/heudiconv/master/docs/tutorials.rst",
+      includeFromStart: false,
+    },
+    // DataLad documentation
+    {
+      title: "DataLad Handbook - Introduction",
+      url: "https://handbook.datalad.org/en/latest/intro/philosophy.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/datalad-handbook/book/main/docs/intro/philosophy.rst",
+      includeFromStart: true,
+    },
+    {
+      title: "DataLad Handbook - Installation",
+      url: "https://handbook.datalad.org/en/latest/intro/installation.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/datalad-handbook/book/main/docs/intro/installation.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "DataLad Handbook - Create Dataset",
+      url: "https://handbook.datalad.org/en/latest/basics/101-101-create.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/datalad-handbook/book/main/docs/basics/101-101-create.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "DataLad Handbook - Version Control",
+      url: "https://handbook.datalad.org/en/latest/basics/101-102-populate.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/datalad-handbook/book/main/docs/basics/101-102-populate.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "DataLad Handbook - Run & Reproducibility",
+      url: "https://handbook.datalad.org/en/latest/basics/101-109-rerun.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/datalad-handbook/book/main/docs/basics/101-109-rerun.rst",
+      includeFromStart: false,
+    },
+    // Neurodocker
+    {
+      title: "Neurodocker README",
+      url: "https://github.com/ReproNim/neurodocker",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/neurodocker/master/README.md",
+      includeFromStart: true,
+    },
+    {
+      title: "Neurodocker Examples",
+      url: "https://github.com/ReproNim/neurodocker/tree/master/examples",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/neurodocker/master/examples/README.md",
+      includeFromStart: false,
+    },
+    // ReproIn
+    {
+      title: "ReproIn README",
+      url: "https://github.com/ReproNim/reproin",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reproin/master/README.md",
+      includeFromStart: false,
+    },
+    // ReproNim containers
+    {
+      title: "ReproNim Containers README",
+      url: "https://github.com/ReproNim/containers",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/containers/master/README.md",
+      includeFromStart: false,
+    },
+    // datalad-container
+    {
+      title: "DataLad-Container README",
+      url: "https://github.com/datalad/datalad-container",
+      sourceUrl:
+        "https://raw.githubusercontent.com/datalad/datalad-container/main/README.md",
+      includeFromStart: false,
+    },
+    // ReproSchema
+    {
+      title: "ReproSchema README",
+      url: "https://github.com/ReproNim/reproschema",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reproschema/master/README.md",
+      includeFromStart: false,
+    },
+    // ReproMan
+    {
+      title: "ReproMan README",
+      url: "https://github.com/ReproNim/reproman",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reproman/master/README.md",
+      includeFromStart: false,
+    },
+    // ReproStim documentation
+    {
+      title: "ReproStim Introduction",
+      url: "https://reprostim.readthedocs.io/en/latest/intro/intro.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/intro/intro.rst",
+      includeFromStart: true,
+    },
+    {
+      title: "ReproStim Overview",
+      url: "https://reprostim.readthedocs.io/en/latest/overview/index.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/overview/index.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproStim Installation",
+      url: "https://reprostim.readthedocs.io/en/latest/install/index.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/install/index.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproStim CLI - Main Commands",
+      url: "https://reprostim.readthedocs.io/en/latest/cli/reprostim.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/cli/reprostim.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproStim CLI - Screen Capture",
+      url: "https://reprostim.readthedocs.io/en/latest/cli/reprostim-screencapture.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/cli/reprostim-screencapture.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproStim CLI - Video Capture",
+      url: "https://reprostim.readthedocs.io/en/latest/cli/reprostim-videocapture.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/cli/reprostim-videocapture.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproStim CLI - Time Sync Stimuli",
+      url: "https://reprostim.readthedocs.io/en/latest/cli/timesync-stimuli.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/cli/timesync-stimuli.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproStim CLI - QR Parse",
+      url: "https://reprostim.readthedocs.io/en/latest/cli/qr-parse.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/cli/qr-parse.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproStim CLI - Video Audit",
+      url: "https://reprostim.readthedocs.io/en/latest/cli/video-audit.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/cli/video-audit.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproStim PsychoPy Integration",
+      url: "https://reprostim.readthedocs.io/en/latest/notes/psychopy-notes.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/notes/psychopy-notes.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproStim Container Setup",
+      url: "https://reprostim.readthedocs.io/en/latest/notes/containers.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/notes/containers.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproStim Development",
+      url: "https://reprostim.readthedocs.io/en/latest/dev/index.html",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/dev/index.rst",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproStim README",
+      url: "https://github.com/ReproNim/reprostim",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/reprostim/master/README.md",
+      includeFromStart: false,
+    },
+    // Training modules
+    {
+      title: "ReproNim Module - Introduction",
+      url: "http://www.repronim.org/module-intro/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/module-intro/gh-pages/README.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Module - Reproducibility Basics",
+      url: "http://www.repronim.org/module-reproducible-basics/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/module-reproducible-basics/gh-pages/README.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Module - FAIR Data",
+      url: "http://www.repronim.org/module-FAIR-data/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/module-FAIR-data/gh-pages/README.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Module - Data Processing",
+      url: "http://www.repronim.org/module-dataprocessing/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/ReproNim/module-dataprocessing/gh-pages/README.md",
+      includeFromStart: false,
+    },
+  ];
+};
+
+export const execute = async (
+  params: RetrieveRepronimDocsParams,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _o: any,
+): Promise<{ result: string }> => {
+  const { urls } = params;
+
+  try {
+    // Fetch content for each URL
+    const results = await Promise.all(
+      urls.map(async (url) => {
+        const sourceUrl = await getSourceUrl(url);
+        const response = await fetch(sourceUrl);
+        if (!response.ok) {
+          return { url, content: `Error: ${response.statusText}` };
+        }
+        const content = await response.text();
+        return { url, content };
+      }),
+    );
+
+    return { result: JSON.stringify(results, null, 2) };
+  } catch (error) {
+    console.warn("Error in retrieve_repronim_docs:", error);
+    return { result: error instanceof Error ? error.message : "Unknown error" };
+  }
+};
+
+const getSourceUrl = async (url: string): Promise<string> => {
+  const docPages = getDocPages();
+  const doc = docPages.find((d) => d.url === url);
+  if (!doc) throw new Error(`Unsupported URL: ${url}`);
+  return doc.sourceUrl;
+};
+
+export const getDetailedDescription = async () => {
+  const docPages = getDocPages();
+
+  const preloadedContent: { [url: string]: string } = {};
+  for (const doc of docPages) {
+    if (doc.includeFromStart) {
+      try {
+        const response = await fetch(doc.sourceUrl);
+        if (response.ok) {
+          preloadedContent[doc.url] = await response.text();
+        } else {
+          preloadedContent[doc.url] =
+            `Error fetching document: ${response.statusText}`;
+        }
+      } catch (error) {
+        preloadedContent[doc.url] = `Error fetching document: ${
+          error instanceof Error ? error.message : "Unknown error"
+        }`;
+      }
+    }
+  }
+  const list: string[] = [];
+  for (const doc of docPages) {
+    const additionalInfo = doc.includeFromStart
+      ? " (already included below)"
+      : "";
+    list.push(`- ${doc.title}: ${doc.url}${additionalInfo}`);
+  }
+  const retLines: string[] = [];
+  retLines.push(
+    "Retrieve content from a list of ReproNim and related tool documentation URLs.",
+  );
+  retLines.push("");
+
+  retLines.push(
+    "The tool first validates that all provided URLs are in the allowed list.",
+  );
+  retLines.push("");
+
+  retLines.push("The output is a JSON array where each element has the form:");
+  retLines.push("{");
+  retLines.push(`  "url": "document URL"`);
+  retLines.push(`  "content": "document content"`);
+  retLines.push("}");
+  retLines.push("");
+
+  retLines.push(
+    "Here is the list of all available ReproNim and related documentation:",
+  );
+  for (const a of list) {
+    retLines.push(a);
+  }
+  retLines.push("");
+
+  if (docPages.filter((doc) => doc.includeFromStart).length > 0) {
+    retLines.push(
+      "Here are the contents of some of those documents which have been preloaded:",
+    );
+    for (const doc of docPages.filter((doc) => doc.includeFromStart)) {
+      retLines.push("");
+      retLines.push(`### ${doc.title}`);
+      retLines.push("");
+      retLines.push(doc.url);
+      retLines.push("");
+      retLines.push("```");
+      retLines.push(preloadedContent[doc.url]);
+      retLines.push("```");
+      retLines.push("");
+    }
+  }
+
+  return retLines.join("\n");
+};
+
+export const requiresPermission = false;
+
+export const createToolCallView = (
+  toolCall: ORToolCall,
+  toolOutput: (ChatMessage & { role: "tool" }) | undefined,
+): React.JSX.Element => {
+  const args = JSON.parse(toolCall.function.arguments || "{}");
+  const urls: string[] = args.urls || [];
+  if (!toolOutput) {
+    return (
+      <div className="tool-call-message">
+        Calling {toolCall.function.name} to retrieve {urls.length} document
+        {urls.length === 1 ? "" : "s"}...
+      </div>
+    );
+  } else {
+    return (
+      <div className="tool-call-message">
+        retrieved{" "}
+        {urls.map((url) => {
+          const parts = url.split("/");
+          const fileName = parts[parts.length - 1] || parts[parts.length - 2];
+          return (
+            <span key={url}>
+              <a href={url} target="_blank" rel="noreferrer">
+                {fileName}
+              </a>
+              &nbsp;
+            </span>
+          );
+        })}
+      </div>
+    );
+  }
+};

--- a/src/tools/getTools.ts
+++ b/src/tools/getTools.ts
@@ -10,6 +10,7 @@ import getDandisetExplorerTools from "../assistants/dandiset-explorer/getTools";
 import getFigpackAssistantTools from "../assistants/figpack-assistant/getTools";
 import getBidsAssistantTools from "../assistants/bids-assistant/getTools";
 import getHedAssistantTools from "../assistants/hed-assistant/getTools";
+import getRepronimAssistantTools from "../assistants/repronim-assistant/getTools";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const getTools = async (_chat: Chat): Promise<QPTool[]> => {
@@ -30,6 +31,8 @@ const getTools = async (_chat: Chat): Promise<QPTool[]> => {
     return getBidsAssistantTools();
   } else if (appName === "hed-assistant") {
     return getHedAssistantTools();
+  } else if (appName === "repronim-assistant") {
+    return getRepronimAssistantTools();
   } else {
     return Promise.resolve([]);
   }


### PR DESCRIPTION
New assistant providing guidance on ReproNim ecosystem including:
- HeuDiConv for DICOM to BIDS conversion
- DataLad for data version control
- Neurodocker for container generation
- ReproStim for stimulus capture and time synchronization
- ReproIn, ReproMan, ReproSchema, and training modules

Features documentation retrieval tool with 33 indexed docs from readthedocs and GitHub, cross-references to related assistants (BIDS, HED, NWB, Dandiset Explorer), and comprehensive test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@magland how do we work with it locally ATM? trying lead me to

http://repronim-assistant.localhost:5173/chat

<img width="3410" height="1264" alt="image" src="https://github.com/user-attachments/assets/2d06b43b-d23e-4b38-a8d2-fe49236b9b10" />
