### PR TITLE
Prioritize repronim.org content in documentation retrieval

### DIFF
--- a/src/assistants/repronim-assistant/integration.test.ts
+++ b/src/assistants/repronim-assistant/integration.test.ts
@@ -83,6 +83,12 @@ describe('ReproNim Assistant - Integration', () => {
       const toolPath = join(process.cwd(), 'src/assistants/repronim-assistant/retrieveRepronimDocs.tsx');
       const content = readFileSync(toolPath, 'utf8');
 
+      // Check for PRIMARY repronim.org content
+      expect(content).toContain('repronim.org/about/why');
+      expect(content).toContain('repronim.org/resources/getting-started');
+      expect(content).toContain('repronim.org/resources/tutorials');
+      expect(content).toContain('repronim.org/resources/tools');
+
       // Check for key ReproNim tools/resources
       expect(content).toContain('HeuDiConv');
       expect(content).toContain('DataLad');
@@ -99,10 +105,10 @@ describe('ReproNim Assistant - Integration', () => {
       expect(content).toContain('module-reproducible-basics');
       expect(content).toContain('module-FAIR-data');
 
-      // Verify we have a reasonable number of docs (now including ReproStim docs)
+      // Verify we have a reasonable number of docs (now including repronim.org + tool docs)
       const docMatches = content.match(/title:/g);
       expect(docMatches).toBeDefined();
-      expect(docMatches!.length).toBeGreaterThan(25); // At least 25 docs with ReproStim
+      expect(docMatches!.length).toBeGreaterThan(40); // At least 40 docs with repronim.org content
     });
 
     it('should have preloaded documents configured', () => {

--- a/src/assistants/repronim-assistant/repronimAssistantSystemPrompt.ts
+++ b/src/assistants/repronim-assistant/repronimAssistantSystemPrompt.ts
@@ -55,15 +55,32 @@ Note that both provide DataLad (git/git-annex) support to access their data.
 
 ## ReproNim Training Resources
 
-ReproNim provides extensive training materials:
+ReproNim provides extensive training materials organized around four principles of reproducible neuroimaging:
+
+### Four Principles
+1. **Study Planning** - Cost estimation, data management plans
+2. **Data & Metadata Management** - BIDS conversion, data dictionaries, annotations
+3. **Software Management** - Version control (Git), containerization, workflow standardization
+4. **Publishing Everything** - Open science practices, reproducible papers
+
+### Primary Resources (repronim.org)
+- **Getting Started Guide**: https://repronim.org/resources/getting-started/ - Persona-based guidance for different researcher types
+- **Tutorials**: https://repronim.org/resources/tutorials/ - Step-by-step practical guides organized by principle
+- **Tools Overview**: https://repronim.org/resources/tools/ - Comprehensive tool catalog
+- **Training Programs**: https://repronim.org/resources/training/ - Courses and fellowship opportunities
+
+### Training Programs
+- **First Fridays Webinars**: Monthly webinar series on reproducibility (available at https://www.youtube.com/@repronim)
+- **ABCD-ReproNim Course**: 12-week course on reproducible analysis of large datasets
+- **Fellowship Program**: Train-the-trainer program for reproducibility education
+- **ReproRehab**: Rehabilitation research focus
+
+### Legacy Modular Curriculum
 - **Module Introduction**: http://www.repronim.org/module-intro/
 - **Reproducibility Basics** (shell, git, package managers): http://www.repronim.org/module-reproducible-basics/
 - **FAIR Data**: http://www.repronim.org/module-FAIR-data/
 - **Data Processing**: http://www.repronim.org/module-dataprocessing/
 - **Statistics**: http://www.repronim.org/module-stats/
-- **First Fridays Webinars**: Monthly webinar series on reproducibility
-- **ABCD-ReproNim Course**: 12-week course on reproducible analysis of large datasets
-- **Fellowship Program**: Train-the-trainer program for reproducibility education
 
 ## Related Specialized Assistants
 
@@ -97,6 +114,11 @@ Be concise in your answers, including only the most relevant information unless 
 
 Before responding, use the retrieve_repronim_docs tool to get any documentation you need.
 Include links to relevant documents in your response.
+
+**Document Priority:**
+1. First, consult repronim.org content (Getting Started, Tutorials, Tools Overview) - these are the primary authoritative resources
+2. Then, consult tool-specific documentation (HeuDiConv, DataLad Handbook, ReproStim docs) for technical details
+3. Legacy training modules for deep dives into specific topics
 
 Do not retrieve docs that have already been loaded or preloaded.
 Retrieve multiple relevant documents at once so you have all the information needed.

--- a/src/assistants/repronim-assistant/retrieveRepronimDocs.test.ts
+++ b/src/assistants/repronim-assistant/retrieveRepronimDocs.test.ts
@@ -23,12 +23,11 @@ describe('ReproNim Assistant - retrieveRepronimDocs', () => {
 
       expect(preloadedDocs.length).toBeGreaterThan(0);
 
-      // Verify key documents are preloaded
+      // Verify repronim.org core content is preloaded (primary resources)
       const titles = preloadedDocs.map(doc => doc.title);
-      expect(titles.some(t => t.includes('HeuDiConv'))).toBe(true);
-      expect(titles.some(t => t.includes('DataLad'))).toBe(true);
-      expect(titles.some(t => t.includes('Neurodocker'))).toBe(true);
-      expect(titles.some(t => t.includes('ReproStim'))).toBe(true);
+      expect(titles.some(t => t.includes('Why Reproducible'))).toBe(true);
+      expect(titles.some(t => t.includes('ReproNim Approach'))).toBe(true);
+      expect(titles.some(t => t.includes('Getting Started'))).toBe(true);
     });
 
     it('should have valid URLs for all documents', () => {
@@ -66,6 +65,18 @@ describe('ReproNim Assistant - retrieveRepronimDocs', () => {
       expect(titles).toContain('Introduction');
       expect(titles).toContain('CLI');
       expect(titles).toContain('Installation');
+    });
+
+    it('should prioritize repronim.org content first in the list', () => {
+      const docPages = getDocPages();
+
+      // First documents should be from repronim.org
+      const firstFiveTitles = docPages.slice(0, 5).map(doc => doc.title);
+      expect(firstFiveTitles.every(t => t.startsWith('ReproNim -') || t.startsWith('ReproNim Tutorial'))).toBe(true);
+
+      // Should include tutorials from repronim.org
+      const repronimOrgDocs = docPages.filter(doc => doc.url.includes('repronim.org'));
+      expect(repronimOrgDocs.length).toBeGreaterThan(10);
     });
 
     it('should include training modules', () => {

--- a/src/assistants/repronim-assistant/retrieveRepronimDocs.tsx
+++ b/src/assistants/repronim-assistant/retrieveRepronimDocs.tsx
@@ -34,13 +34,153 @@ export type DocPage = {
 
 export const getDocPages = (): DocPage[] => {
   return [
+    // =====================================================
+    // PRIMARY: ReproNim.org website content (from Hugo site)
+    // These are the authoritative resources and should be consulted first
+    // =====================================================
+
+    // About & Core Concepts
+    {
+      title: "ReproNim - Why Reproducible Neuroimaging",
+      url: "https://repronim.org/about/why/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/about/why.md",
+      includeFromStart: true,
+    },
+    {
+      title: "ReproNim - The ReproNim Approach",
+      url: "https://repronim.org/about/repronim-approach/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/about/repronim-approach.md",
+      includeFromStart: true,
+    },
+    {
+      title: "ReproNim - Getting Started",
+      url: "https://repronim.org/resources/getting-started/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/getting-started/_index.md",
+      includeFromStart: true,
+    },
+    {
+      title: "ReproNim - Tools Overview",
+      url: "https://repronim.org/resources/tools/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tools/_index.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim - Training Overview",
+      url: "https://repronim.org/resources/training/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/training/_index.md",
+      includeFromStart: false,
+    },
+
+    // Tutorials from repronim.org (Principle-based organization)
+    {
+      title: "ReproNim Tutorial - Tutorials Overview",
+      url: "https://repronim.org/resources/tutorials/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/_index.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - DICOM to BIDS Conversion",
+      url: "https://repronim.org/resources/tutorials/dicom-to-bids/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/dicom-to-bids.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - Data Dictionary",
+      url: "https://repronim.org/resources/tutorials/data-dictionary/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/data-dictionary.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - Data Management and Sharing",
+      url: "https://repronim.org/resources/tutorials/data-management-and-sharing/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/data-management-and-sharing.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - Estimating Costs",
+      url: "https://repronim.org/resources/tutorials/estimating-costs/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/estimating-costs.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - Git Version Control",
+      url: "https://repronim.org/resources/tutorials/git/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/git.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - Neurodocker Containerization",
+      url: "https://repronim.org/resources/tutorials/neurodocker/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/neurodocker.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - ReproNim Containers with DataLad",
+      url: "https://repronim.org/resources/tutorials/repronim-containers/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/repronim-containers.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - ReproSchema",
+      url: "https://repronim.org/resources/tutorials/reproschema/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/reproschema.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - Nipoppy Workflow",
+      url: "https://repronim.org/resources/tutorials/nipoppy/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/nipoppy.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - FreeSurfer",
+      url: "https://repronim.org/resources/tutorials/freesurfer/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/freesurfer.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - FSL",
+      url: "https://repronim.org/resources/tutorials/fsl/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/fsl.md",
+      includeFromStart: false,
+    },
+    {
+      title: "ReproNim Tutorial - Publish Everything",
+      url: "https://repronim.org/resources/tutorials/publish-everything/",
+      sourceUrl:
+        "https://raw.githubusercontent.com/repronim/repronim.org/main/content/resources/tutorials/publish-everything.md",
+      includeFromStart: false,
+    },
+
+    // =====================================================
+    // SECONDARY: Tool-specific documentation
+    // Detailed technical docs for individual tools
+    // =====================================================
+
     // HeuDiConv documentation
     {
       title: "HeuDiConv Quickstart",
       url: "https://heudiconv.readthedocs.io/en/latest/quickstart.html",
       sourceUrl:
         "https://raw.githubusercontent.com/nipy/heudiconv/master/docs/quickstart.rst",
-      includeFromStart: true,
+      includeFromStart: false,
     },
     {
       title: "HeuDiConv Installation",
@@ -63,13 +203,14 @@ export const getDocPages = (): DocPage[] => {
         "https://raw.githubusercontent.com/nipy/heudiconv/master/docs/tutorials.rst",
       includeFromStart: false,
     },
+
     // DataLad documentation
     {
       title: "DataLad Handbook - Introduction",
       url: "https://handbook.datalad.org/en/latest/intro/philosophy.html",
       sourceUrl:
         "https://raw.githubusercontent.com/datalad-handbook/book/main/docs/intro/philosophy.rst",
-      includeFromStart: true,
+      includeFromStart: false,
     },
     {
       title: "DataLad Handbook - Installation",
@@ -99,13 +240,14 @@ export const getDocPages = (): DocPage[] => {
         "https://raw.githubusercontent.com/datalad-handbook/book/main/docs/basics/101-109-rerun.rst",
       includeFromStart: false,
     },
+
     // Neurodocker
     {
       title: "Neurodocker README",
       url: "https://github.com/ReproNim/neurodocker",
       sourceUrl:
         "https://raw.githubusercontent.com/ReproNim/neurodocker/master/README.md",
-      includeFromStart: true,
+      includeFromStart: false,
     },
     {
       title: "Neurodocker Examples",
@@ -114,6 +256,7 @@ export const getDocPages = (): DocPage[] => {
         "https://raw.githubusercontent.com/ReproNim/neurodocker/master/examples/README.md",
       includeFromStart: false,
     },
+
     // ReproIn
     {
       title: "ReproIn README",
@@ -122,6 +265,7 @@ export const getDocPages = (): DocPage[] => {
         "https://raw.githubusercontent.com/ReproNim/reproin/master/README.md",
       includeFromStart: false,
     },
+
     // ReproNim containers
     {
       title: "ReproNim Containers README",
@@ -130,6 +274,7 @@ export const getDocPages = (): DocPage[] => {
         "https://raw.githubusercontent.com/ReproNim/containers/master/README.md",
       includeFromStart: false,
     },
+
     // datalad-container
     {
       title: "DataLad-Container README",
@@ -138,6 +283,7 @@ export const getDocPages = (): DocPage[] => {
         "https://raw.githubusercontent.com/datalad/datalad-container/main/README.md",
       includeFromStart: false,
     },
+
     // ReproSchema
     {
       title: "ReproSchema README",
@@ -146,6 +292,7 @@ export const getDocPages = (): DocPage[] => {
         "https://raw.githubusercontent.com/ReproNim/reproschema/master/README.md",
       includeFromStart: false,
     },
+
     // ReproMan
     {
       title: "ReproMan README",
@@ -154,13 +301,14 @@ export const getDocPages = (): DocPage[] => {
         "https://raw.githubusercontent.com/ReproNim/reproman/master/README.md",
       includeFromStart: false,
     },
+
     // ReproStim documentation
     {
       title: "ReproStim Introduction",
       url: "https://reprostim.readthedocs.io/en/latest/intro/intro.html",
       sourceUrl:
         "https://raw.githubusercontent.com/ReproNim/reprostim/master/docs/source/intro/intro.rst",
-      includeFromStart: true,
+      includeFromStart: false,
     },
     {
       title: "ReproStim Overview",
@@ -246,7 +394,11 @@ export const getDocPages = (): DocPage[] => {
         "https://raw.githubusercontent.com/ReproNim/reprostim/master/README.md",
       includeFromStart: false,
     },
-    // Training modules
+
+    // =====================================================
+    // TERTIARY: Legacy training modules
+    // Older modular curriculum (still useful for deep dives)
+    // =====================================================
     {
       title: "ReproNim Module - Introduction",
       url: "http://www.repronim.org/module-intro/",


### PR DESCRIPTION
Reorganize documentation with three-tier priority:
1. PRIMARY: repronim.org website content (18 docs) including Getting Started, Tutorials, Tools Overview, and core about pages
2. SECONDARY: Tool-specific docs (HeuDiConv, DataLad, ReproStim, etc.)
3. TERTIARY: Legacy training modules

Update system prompt with:
- Four Principles framework for reproducible neuroimaging
- Document priority guidance preferring repronim.org content
- YouTube channel link for First Fridays webinars (ref #30 )

🤖 Generated with [Claude Code](https://claude.com/claude-code)

and thank you @magland -- I could test it locally now!