### PR TITLE
Allow airesearchcoach.org origin

### DIFF
--- a/worker/src/utils/cors.ts
+++ b/worker/src/utils/cors.ts
@@ -7,7 +7,8 @@ const ALLOWED_ORIGINS = [
   'https://magland.github.io',
   'https://dandi.github.io',
   'https://medit.dandiarchive.org',
-  "https://dandiset-metadata-assistant.surge.sh"
+  "https://dandiset-metadata-assistant.surge.sh",
+  'https://airesearchcoach.org'
 ];
 
 export function isOriginAllowed(origin: string | null): boolean {


### PR DESCRIPTION
## Summary
Adds `https://airesearchcoach.org` to the worker's `ALLOWED_ORIGINS` so a chatgeneral-derived app deployed at that origin can call the completion proxy.

## Test plan
- [ ] Deploy worker and confirm a `POST /api/completion` request from `https://airesearchcoach.org` receives proper CORS headers.

Made with [Cursor](https://cursor.com)